### PR TITLE
Prometheus: custom rule and alert manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ while true; do curl -s http://192.168.56.91:80/; sleep 0.1; done
 ```
 This generates approximately 10 requests per second, which is well above the threshold.
 
-### 5. Verify Alert Status and Email Notification
+### 5. Verify Alert Status
 
 In the Prometheus UI under **Alerts**, verify that the alert transitions from **Pending** to **Firing** after approximately 2m. 
 
@@ -217,8 +217,8 @@ Check the Alertmanager UI to confirm that it received and processed the alert:
 kubectl port-forward -n monitoring svc/alertmanager-operated 9093
 ```
 
-Then visit: [http://localhost:9093](http://localhost:9093)
-You should see the alert listed there, with the configured receiver (email, etc.).
+Then visit: [http://localhost:9093](http://localhost:9093).
+You should see the alert listed there.
 
 ## Grafana 
 We provide a pre-configured dashboard for monitoring with 4 pannels:

--- a/README.md
+++ b/README.md
@@ -143,8 +143,6 @@ kubectl get pods -o wide
 # model-service-5987884b9-mjjln   1/1     Running   0          46m   10.244.1.7   k8s-node-1   <none>           <none>
 ```
 
-
-
 ## Check if Prometheus works
 
 ### 1. Access Prometheus Web UI
@@ -168,7 +166,59 @@ kubectl port-forward svc/sentiment-app-app 8080:8080
 curl http://localhost:8080/metrics
 ```
 
+## Test Alerting Capabilities 
 
+### 1. Create a Kubernetes Secret for SMTP Credentials
+
+Use the following command to create a secret containing fake (or real, for production) SMTP credentials.
+
+```bash
+kubectl create secret generic alertmanager-smtp-secret \
+  --from-literal=smtp_username=fake-user@example.com \
+  --from-literal=smtp_password=fake-password \
+  -n monitoring
+```
+
+### 2. Re-deploy the Application 
+
+Re-run the deployment to apply changes, including alerting configuration:
+```bash
+./run-all.sh
+```
+This ensures that Alertmanager picks up the config and mounts the secret properly.
+
+### 3. Access Prometheus and Locate the Alert
+
+Forward Prometheus to your local machine:
+```sh
+kubectl port-forward -n monitoring svc/prometheus-kube-prometheus-prometheus 9090:9090
+```
+
+Then open your browser and visit:
+[http://localhost:9090](http://localhost:9090)
+
+Look for the custom alert "HighRequestRate" in the list. If it's correctly configured and active, it will appear as Inactive, Pending or Firing.
+
+### 4. Trigger the Alert by Generating Traffic
+
+To exceed the alert threshold, simulate traffic:
+```bash
+while true; do curl -s http://192.168.56.91:80/; sleep 0.1; done
+```
+This generates approximately 10 requests per second, which is well above the threshold.
+
+### 5. Verify Alert Status and Email Notification
+
+In the Prometheus UI under **Alerts**, verify that the alert transitions from **Pending** to **Firing** after approximately 2m. 
+
+Check the Alertmanager UI to confirm that it received and processed the alert:
+
+```bash
+kubectl port-forward -n monitoring svc/alertmanager-operated 9093
+```
+
+Then visit: [http://localhost:9093](http://localhost:9093)
+You should see the alert listed there, with the configured receiver (email, etc.).
 
 ## Grafana 
 We provide a pre-configured dashboard for monitoring with 4 pannels:

--- a/helm_chart/templates/promethues/alertmanager.yaml
+++ b/helm_chart/templates/promethues/alertmanager.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.alertmanager.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-alertmanager-config
+  namespace: {{ .Values.alertmanager.namespace }}
+  labels:
+    app: alertmanager
+    release: {{ .Release.Name }}
+type: Opaque
+stringData:
+  alertmanager.yaml: |
+    global:
+      smtp_smarthost: '{{ .Values.alertmanager.smtp_smarthost }}'
+      smtp_from: '{{ .Values.alertmanager.smtp_from }}'
+      smtp_auth_username: "${SMTP_USERNAME}"
+      smtp_auth_password: "${SMTP_PASSWORD}"
+      smtp_require_tls: true
+
+    route:
+      receiver: 'email'
+      group_by: ['alertname']
+      group_wait: 30s
+      group_interval: 5m
+      repeat_interval: 6h
+
+    receivers:
+    - name: 'email'
+      email_configs:
+      - to: '{{ .Values.alertmanager.smtp_to }}'
+        send_resolved: true
+{{- end }}

--- a/helm_chart/templates/promethues/prometheusrule.yaml
+++ b/helm_chart/templates/promethues/prometheusrule.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.prometheusRule.enabled }}
+{{- range .Values.monitoring.targets }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata: 
+  name: {{ $.Release.Name }}-{{ .name }}-rules
+  namespace: {{ $.Values.prometheusRule.namespace }}
+  labels:
+    app: {{ $.Release.Name }}-{{ .name }}
+    release: {{ $.Values.monitoring.release }}
+spec:
+  groups:
+  - name: {{ $.Values.prometheusRule.groupName }}-{{ .name }}.rules
+    rules: 
+    - alert: {{ $.Values.prometheusRule.name }}-{{ .name }}
+      expr: {{ $.Values.prometheusRule.expr }}
+      for: {{ $.Values.prometheusRule.for }}
+      labels:
+        severity: {{ $.Values.prometheusRule.severity }}
+      annotations:
+        summary: {{ $.Values.prometheusRule.summary }}
+        description: {{ $.Values.prometheusRule.description }}
+---
+{{- end }}
+{{- end }}
+
+{{- if .Values.alertmanager.enabled }}

--- a/helm_chart/templates/promethues/prometheusrule.yaml
+++ b/helm_chart/templates/promethues/prometheusrule.yaml
@@ -1,18 +1,17 @@
 {{- if .Values.prometheusRule.enabled }}
-{{- range .Values.monitoring.targets }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata: 
-  name: {{ $.Release.Name }}-{{ .name }}-rules
+  name: {{ $.Release.Name }}-rules
   namespace: {{ $.Values.prometheusRule.namespace }}
   labels:
-    app: {{ $.Release.Name }}-{{ .name }}
+    app: {{ $.Release.Name }}
     release: {{ $.Values.monitoring.release }}
 spec:
   groups:
-  - name: {{ $.Values.prometheusRule.groupName }}-{{ .name }}.rules
+  - name: {{ $.Values.prometheusRule.groupName }}.rules
     rules: 
-    - alert: {{ $.Values.prometheusRule.name }}-{{ .name }}
+    - alert: {{ $.Values.prometheusRule.name }}
       expr: {{ $.Values.prometheusRule.expr }}
       for: {{ $.Values.prometheusRule.for }}
       labels:
@@ -20,8 +19,4 @@ spec:
       annotations:
         summary: {{ $.Values.prometheusRule.summary }}
         description: {{ $.Values.prometheusRule.description }}
----
 {{- end }}
-{{- end }}
-
-{{- if .Values.alertmanager.enabled }}

--- a/helm_chart/values.yaml
+++ b/helm_chart/values.yaml
@@ -270,9 +270,9 @@ alertmanager:
   enabled: true
   namespace: monitoring
 
-  smtp_smarthost: smtp.fakehost.test:587
-  smtp_from: alert@example.com
-  smtp_to: test@example.com
+  smtp_smarthost: smtp.example.com:587
+  smtp_from: alertmanager@example.com
+  smtp_to: dev-team@example.com 
 
   alertmanagerSpec:
     configSecret: alertmanager-config 

--- a/helm_chart/values.yaml
+++ b/helm_chart/values.yaml
@@ -236,6 +236,8 @@ prometheus:
   prometheusSpec:
     serviceMonitorSelector: {}
     serviceMonitorNamespaceSelector: {}
+    ruleSelector: {}
+    ruleNamespaceSelector: {}
 # ─────────────────────────────────────────────────────────────────────────────
 monitoring:
   enabled: true
@@ -250,7 +252,7 @@ monitoring:
     #   port: web
     #   path: /metrics
     #   interval: 15s
-─────────────────────────────────────────────────────────────────────────────
+# ─────────────────────────────────────────────────────────────────────────────
 prometheusRule:
   enabled: true
   namespace: monitoring
@@ -258,8 +260,30 @@ prometheusRule:
 
   groupName: app
   name: HighRequestRate
-  expr: rate(http_requests_total[1m]) > 0.25
+  expr: rate(flask_http_request_total[1m]) > 0.25
   for: 2m
   severity: warning
   summary: "High request rate detected"
   description: "More than 15 requests per minute for two minutes straight."
+# ─────────────────────────────────────────────────────────────────────────────
+alertmanager:
+  enabled: true
+  namespace: monitoring
+
+  smtp_smarthost: smtp.fakehost.test:587
+  smtp_from: alert@example.com
+  smtp_to: test@example.com
+
+  alertmanagerSpec:
+    configSecret: alertmanager-config 
+    env:
+      - name: SMTP_USERNAME
+        valueFrom:
+          secretKeyRef:
+            name: alertmanager-smtp-secret
+            key: smtp_username
+      - name: SMTP_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: alertmanager-smtp-secret
+            key: smtp_password

--- a/helm_chart/values.yaml
+++ b/helm_chart/values.yaml
@@ -232,12 +232,10 @@ virtualServices:
 secret:
   key: "secret" 
 # ─────────────────────────────────────────────────────────────────────────────
-
 prometheus:
   prometheusSpec:
     serviceMonitorSelector: {}
     serviceMonitorNamespaceSelector: {}
-
 # ─────────────────────────────────────────────────────────────────────────────
 monitoring:
   enabled: true
@@ -252,3 +250,16 @@ monitoring:
     #   port: web
     #   path: /metrics
     #   interval: 15s
+─────────────────────────────────────────────────────────────────────────────
+prometheusRule:
+  enabled: true
+  namespace: monitoring
+  release: prometheus
+
+  groupName: app
+  name: HighRequestRate
+  expr: rate(http_requests_total[1m]) > 0.25
+  for: 2m
+  severity: warning
+  summary: "High request rate detected"
+  description: "More than 15 requests per minute for two minutes straight."


### PR DESCRIPTION
This PR introduces the following:
- [x] An AlertManager is configured with one non-trivial PrometheusRule (HighRequestRate).
- [x] A corresponding Alert is raised via email.
- [x] A Kubernetes Secret is used for SMTP credentials.
- [x] README includes steps on how to test the custom rule.

Potential improvements:
- Include the creation of SMTP credentials in "run-all.sh". 